### PR TITLE
Remove unused import

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 import math
 import sys
 from sklearn.datasets import fetch_20newsgroups
-import random
 
 # Download required NLTK resources
 try:


### PR DESCRIPTION
## Summary
- remove unused `random` import from `main.py`

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'nltk')*

------
https://chatgpt.com/codex/tasks/task_e_684dea03946c8327a5da7904ab24b660